### PR TITLE
modify multi-table.sql to use BIGINT type for uptime_ms columns

### DIFF
--- a/db/multi-table.sql
+++ b/db/multi-table.sql
@@ -10,7 +10,7 @@ CREATE TABLE heartbeat (
     time_received TIMESTAMP NOT NULL,
     schema INTEGER,
     node_addr INTEGER,
-    uptime_ms INTEGER,
+    uptime_ms BIGINT,
     batt_mv INTEGER
 );
 
@@ -23,7 +23,7 @@ CREATE TABLE apple (
     time_received TIMESTAMP NOT NULL,
     schema INTEGER,
     node_addr INTEGER,
-    uptime_ms INTEGER,
+    uptime_ms BIGINT,
     batt_mv INTEGER,
     panel_mv INTEGER,
     press_pa INTEGER,
@@ -41,7 +41,7 @@ CREATE TABLE cranberry (
     time_received TIMESTAMP NOT NULL,
     schema INTEGER,
     node_addr INTEGER,
-    uptime_ms INTEGER,
+    uptime_ms BIGINT,
     batt_mv INTEGER,
     panel_mv INTEGER,
     apogee_w_m2 INTEGER,
@@ -59,7 +59,7 @@ CREATE TABLE dragonfruit (
     time_received TIMESTAMP NOT NULL,
     schema INTEGER,
     node_addr INTEGER,
-    uptime_ms INTEGER,
+    uptime_ms BIGINT,
     batt_mv INTEGER,
     panel_mv INTEGER,
     apogee_sp215 INTEGER,


### PR DESCRIPTION
Altered the multi-table.sql file to use BIGINT data type for uptime_ms field as opposed to previously using the INTEGER data type.