### PR TITLE
Gateway: re-enable database writes

### DIFF
--- a/gateway/src/gateway_server.py
+++ b/gateway/src/gateway_server.py
@@ -74,7 +74,7 @@ while True:
 
 	decoder.register_callback(decoder.print_dictionary)
 	decoder.register_callback(decoder.write_to_file)
-	# decoder.register_callback(decoder.write_to_db)
+	decoder.register_callback(decoder.write_to_db)
 	xbg.register_callback(decoder.decode_data)
 
 	xbg.setup_xbee(port, baud_rate)


### PR DESCRIPTION
This PR  is a request from the current firmware team to re-enable database writes. **Note**: After merging, make sure to run `git pull origin master` in the directory where the production code lives.

You should also be able to check if data is being written by using the command below, which grabs the latest rows.

```
scel@scelserver-1:~$ psql -U control_tower_ro -d control_tower -c "SELECT * FROM apple ORDER BY time_received DESC LIMIT 10"
       time_received        | schema | node_addr | uptime_ms | batt_mv | panel_mv | press_pa | temp_c | humidity_centi_pct | apogee_w_m2
----------------------------+--------+-----------+-----------+---------+----------+----------+--------+--------------------+-------------
 2020-02-11 15:43:09.275264 |      1 |       420 |  21540032 |    3484 |     4605 |   100361 |    402 |              65532 |         292
 2020-02-11 15:42:39.248188 |      1 |       420 |  21510032 |    3548 |     4605 |   100358 |    402 |              65532 |       295.5
 2020-02-11 15:42:09.23702  |      1 |       420 |  21480032 |    3543 |     4605 |   100364 |    402 |              65532 |       295.5
 2020-02-11 15:41:39.209018 |      1 |       420 |  21450032 |    3514 |     4605 |   100361 |    401 |              65532 |         298
 2020-02-11 15:41:09.196353 |      1 |       420 |  21420032 |    3514 |     4605 |   100371 |    401 |              65532 |       295.5
 2020-02-11 15:40:39.183567 |      1 |       420 |  21390032 |    3475 |     4595 |   100364 |    401 |              65532 |      296.75
 2020-02-11 15:40:09.170768 |      1 |       420 |  21360032 |    3563 |     4605 |   100361 |    400 |              65532 |      299.25
 2020-02-11 15:39:39.141894 |      1 |       420 |  21330032 |    3484 |     4595 |   100366 |    400 |              65532 |         298
 2020-02-11 15:39:09.128975 |      1 |       420 |  21300032 |    3519 |     4595 |   100369 |    399 |              65532 |         298
 2020-02-11 15:38:39.115731 |      1 |       420 |  21270032 |    3538 |     4605 |   100363 |    399 |              65532 |       300.5
(10 rows)
```