### PR TITLE
Fixes an error message from the psycopg2 package

### DIFF
--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 pyserial==3.4
 pyzmq==17.0.0
 XBee==2.3.1


### PR DESCRIPTION
```
   UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
      """)
```