### PR TITLE
changed ga_production board setting

### DIFF
--- a/weatherbox_firmware/platformio.ini
+++ b/weatherbox_firmware/platformio.ini
@@ -37,7 +37,7 @@
 [env:ga_production]
 platform = atmelavr
 framework = arduino
-board = uno
+board = pro8MHzatmega328
 build_flags = -DGA
 src_filter = +<*> -<gen_cranberry/> -<gen_dragonfruit/> -<gen_guava/> -<log.cpp/> -<log.h/> -<README.md/>
 


### PR DESCRIPTION
## Platformio.ini Board setting

* Changed the platformio.ini board setting to pro8MHzatmega328. Previously, team firmware observed nonsense output coming from uploading the firmware with the board setting as "uno". Team firmware changed several other settings: adjusting upload speed, serial.begin speed in ga_board.cpp, and other baud rate related settings. The changes in platformio.ini fixes the nonsense output issue, but doesn't require many manual frequency changes.