### PR TITLE
changed temp_C to temp_K

### DIFF
--- a/gateway/src/decoder.py
+++ b/gateway/src/decoder.py
@@ -174,7 +174,7 @@ class Decoder:
             dataDict["batt_mv"] = unpacked_data[3]
             dataDict["panel_mv"] = unpacked_data[4]
             dataDict["press_pa"] = unpacked_data[5]
-            dataDict["temp_c"] = unpacked_data[6]
+            dataDict["temp_K"] = unpacked_data[6]
             dataDict["humidity_centi_pct"] = unpacked_data[7]
 
             # apple box uses apogee sp215


### PR DESCRIPTION
The test gateway output for the temperature was labeled as being in units of Celsius even though it was in Kelvin. This change replaced the "temp_c" output with "temp_K"  so as to reflect the correct units of the temperature.